### PR TITLE
Fix migration creation in python 2

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -204,26 +204,28 @@ class AttachmentManager(models.Manager):
         ]
 
 
-class Attachment(models.Model):
-    def get_attachment_dir(instance, filename):
-        """
-        The attachment directory to store the file in.
+def get_attachment_dir(instance, filename):
+    """
+    The attachment directory to store the file in.
 
-        Builds the location based on the ATTACHMENT_STORAGE_DIR setting which
-        is a callable (in the same string format as TEMPLATE_LOADERS) that
-        takes an attachment and a filename and then returns a string.
-        """
-        if getattr(settings, 'ATTACHMENT_STORAGE_DIR', None):
-            try:
-                dir_builder = get_callable_from_string(
-                    settings.ATTACHMENT_STORAGE_DIR)
-            except ImproperlyConfigured:
-                # Callable didn't load correctly
-                dir_builder = directory_schemes.by_app
-        else:
+    Builds the location based on the ATTACHMENT_STORAGE_DIR setting which
+    is a callable (in the same string format as TEMPLATE_LOADERS) that
+    takes an attachment and a filename and then returns a string.
+    """
+    if getattr(settings, 'ATTACHMENT_STORAGE_DIR', None):
+        try:
+            dir_builder = get_callable_from_string(
+                settings.ATTACHMENT_STORAGE_DIR)
+        except ImproperlyConfigured:
+            # Callable didn't load correctly
             dir_builder = directory_schemes.by_app
+    else:
+        dir_builder = directory_schemes.by_app
 
-        return dir_builder(instance, filename)
+    return dir_builder(instance, filename)
+
+
+class Attachment(models.Model):
 
     file = models.FileField(_("file"), upload_to=get_attachment_dir,
                             max_length=255)

--- a/attachments/tests.py
+++ b/attachments/tests.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.test import TestCase
 
-from attachments.models import Attachment
+from attachments.models import Attachment, get_attachment_dir
 
 
 class TestModel(models.Model):
@@ -67,7 +67,7 @@ class TestAttachmentCopying(TestCase):
         for attachment in attachments:
             self.assertEqual(
                 attachment.file.name,
-                Attachment.get_attachment_dir(
+                get_attachment_dir(
                     attachment,
                     attachment.file_name(),
                 ),


### PR DESCRIPTION
```
Migrations for 'attachments':
  0001_initial.py:
    - Create model Attachment
Traceback (most recent call last):
  File "./manage.py", line 35, in <module>
    execute_manager()
  File "./manage.py", line 31, in execute_manager 
    utility.execute()
  File "/home/vagrant/env/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/vagrant/env/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/vagrant/env/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/env/lib/python2.7/site-packages/django/core/management/commands/makemigrations.py", line 143, in handle
    self.write_migration_files(changes)
  File "/home/vagrant/env/lib/python2.7/site-packages/django/core/management/commands/makemigrations.py", line 171, in write_migration_files
    migration_string = writer.as_string()
  File "/home/vagrant/env/lib/python2.7/site-packages/django/db/migrations/writer.py", line 165, in as_string
    operation_string, operation_imports = OperationWriter(operation).serialize()
  File "/home/vagrant/env/lib/python2.7/site-packages/django/db/migrations/writer.py", line 123, in serialize
    _write(arg_name, arg_value)
  File "/home/vagrant/env/lib/python2.7/site-packages/django/db/migrations/writer.py", line 75, in _write
    arg_string, arg_imports = MigrationWriter.serialize(item)
  File "/home/vagrant/env/lib/python2.7/site-packages/django/db/migrations/writer.py", line 302, in serialize
    item_string, item_imports = cls.serialize(item)
  File "/home/vagrant/env/lib/python2.7/site-packages/django/db/migrations/writer.py", line 376, in serialize
    return cls.serialize_deconstructed(path, args, kwargs)
  File "/home/vagrant/env/lib/python2.7/site-packages/django/db/migrations/writer.py", line 267, in serialize_deconstructed
    arg_string, arg_imports = cls.serialize(arg)  
  File "/home/vagrant/env/lib/python2.7/site-packages/django/db/migrations/writer.py", line 434, in serialize
    % (value.__name__, module_name, get_docs_version()))
ValueError: Could not find function get_attachment_dir in attachments.models.
Please note that due to Python 2 limitations, you cannot serialize unbound method functions (e.g. a method declared and used in the same class body). Please move the function into the main module body to use migrations.
For more information, see https://docs.djangoproject.com/en/1.8/topics/migrations/#serializing-values
```